### PR TITLE
chore: remove once_cell dependency

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,14 +16,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
       - name: build
         run: |
           cd docs
           npm install
           npm run docs:build
-      - uses: actions/configure-pages@v3
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: docs/.vitepress/dist
-      - uses: actions/deploy-pages@v2
+      - uses: actions/deploy-pages@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     name: lint editorconfig
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: editorconfig
       run: |
           docker run --rm --volume=$PWD:/check mstruebing/editorconfig-checker ec --exclude ".git|\.meta$|\.anim$|\.dds$|\.controller$|\.asset$|\.unity$|\.asmdef$|ProjectSettings"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
   scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v4
+      - uses: actions/stale@v9
         id: stale
         with:
           stale-issue-label: stale

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -344,12 +344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
-name = "once_cell"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
-
-[[package]]
 name = "png"
 version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,10 +481,7 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "sprite_dicing"
-version = "0.1.2"
-dependencies = [
- "once_cell",
-]
+version = "0.1.3"
 
 [[package]]
 name = "strsim"
@@ -515,7 +506,6 @@ version = "0.0.0"
 dependencies = [
  "cli",
  "image",
- "once_cell",
  "rand",
  "serde_json",
  "sprite_dicing",

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sprite_dicing"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Cross-engine tool for lossless compression of sprite textures with identical areas."
 license = "MIT"
@@ -11,8 +11,3 @@ repository = "https://github.com/elringus/sprite-dicing"
 readme = "../../README.md"
 keywords = ["gamedev", "graphics", "sprite", "texture", "atlas"]
 categories = ["game-development", "graphics", "compression"]
-
-[dev-dependencies]
-# TODO: Replace with std::sync::LazyLock when stabilized.
-# https://github.com/rust-lang/rust/issues/109736
-once_cell = "1.19"

--- a/crates/lib/src/fixtures.rs
+++ b/crates/lib/src/fixtures.rs
@@ -1,9 +1,9 @@
 #![cfg(test)]
 
 use crate::models::*;
-use once_cell::sync::Lazy;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::sync::LazyLock;
 
 pub const R: Pixel = Pixel::new(255, 0, 0, 255);
 pub const G: Pixel = Pixel::new(0, 255, 0, 255);
@@ -13,70 +13,70 @@ pub const C: Pixel = Pixel::new(0, 255, 255, 255);
 pub const M: Pixel = Pixel::new(255, 0, 255, 255);
 pub const Y: Pixel = Pixel::new(255, 255, 0, 255);
 
-pub static R1X1: Lazy<Texture> = Lazy::new(|| tex(1, 1, vec![R]));
-pub static G1X1: Lazy<Texture> = Lazy::new(|| tex(1, 1, vec![G]));
-pub static B1X1: Lazy<Texture> = Lazy::new(|| tex(1, 1, vec![B]));
-pub static C1X1: Lazy<Texture> = Lazy::new(|| tex(1, 1, vec![C]));
-pub static M1X1: Lazy<Texture> = Lazy::new(|| tex(1, 1, vec![M]));
-pub static Y1X1: Lazy<Texture> = Lazy::new(|| tex(1, 1, vec![Y]));
+pub static R1X1: LazyLock<Texture> = LazyLock::new(|| tex(1, 1, vec![R]));
+pub static G1X1: LazyLock<Texture> = LazyLock::new(|| tex(1, 1, vec![G]));
+pub static B1X1: LazyLock<Texture> = LazyLock::new(|| tex(1, 1, vec![B]));
+pub static C1X1: LazyLock<Texture> = LazyLock::new(|| tex(1, 1, vec![C]));
+pub static M1X1: LazyLock<Texture> = LazyLock::new(|| tex(1, 1, vec![M]));
+pub static Y1X1: LazyLock<Texture> = LazyLock::new(|| tex(1, 1, vec![Y]));
 #[rustfmt::skip]
-pub static RGBY: Lazy<Texture> = Lazy::new(|| tex(2, 2, vec![
+pub static RGBY: LazyLock<Texture> = LazyLock::new(|| tex(2, 2, vec![
     R, G,
     B, Y
 ]));
 #[rustfmt::skip]
-pub static BGRT: Lazy<Texture> = Lazy::new(|| tex(2, 2, vec![
+pub static BGRT: LazyLock<Texture> = LazyLock::new(|| tex(2, 2, vec![
     B, G,
     R, T
 ]));
 #[rustfmt::skip]
-pub static BTGR: Lazy<Texture> = Lazy::new(|| tex(2, 2, vec![
+pub static BTGR: LazyLock<Texture> = LazyLock::new(|| tex(2, 2, vec![
     B, T,
     G, R
 ]));
 #[rustfmt::skip]
-pub static BTGT: Lazy<Texture> = Lazy::new(|| tex(2, 2, vec![
+pub static BTGT: LazyLock<Texture> = LazyLock::new(|| tex(2, 2, vec![
     B, T,
     G, T
 ]));
 #[rustfmt::skip]
-pub static TTTM: Lazy<Texture> = Lazy::new(|| tex(2, 2, vec![
+pub static TTTM: LazyLock<Texture> = LazyLock::new(|| tex(2, 2, vec![
     T, T,
     T, M
 ]));
 #[rustfmt::skip]
-pub static MTTT: Lazy<Texture> = Lazy::new(|| tex(2, 2, vec![
+pub static MTTT: LazyLock<Texture> = LazyLock::new(|| tex(2, 2, vec![
     M, T,
     T, T
 ]));
 #[rustfmt::skip]
-pub static TTMT: Lazy<Texture> = Lazy::new(|| tex(2, 2, vec![
+pub static TTMT: LazyLock<Texture> = LazyLock::new(|| tex(2, 2, vec![
     T, T,
     M, T
 ]));
 #[rustfmt::skip]
-pub static TTTT: Lazy<Texture> = Lazy::new(|| tex(2, 2, vec![
+pub static TTTT: LazyLock<Texture> = LazyLock::new(|| tex(2, 2, vec![
     T, T,
     T, T
 ]));
 #[rustfmt::skip]
-pub static RGB1X3: Lazy<Texture> = Lazy::new(|| tex(1, 3, vec![
+pub static RGB1X3: LazyLock<Texture> = LazyLock::new(|| tex(1, 3, vec![
     G,
     R,
     B
 ]));
 #[rustfmt::skip]
-pub static RGB3X1: Lazy<Texture> = Lazy::new(|| tex(3, 1, vec![
+pub static RGB3X1: LazyLock<Texture> = LazyLock::new(|| tex(3, 1, vec![
     G, R, B
 ]));
 #[rustfmt::skip]
-pub static RGB4X4: Lazy<Texture> = Lazy::new(|| tex(4, 4, vec![
+pub static RGB4X4: LazyLock<Texture> = LazyLock::new(|| tex(4, 4, vec![
     B, G, G, G,
     R, R, G, B,
     R, G, B, R,
     B, B, R, G,
 ]));
-pub static PLT4X4: Lazy<Texture> = Lazy::new(|| palette(4, 4));
+pub static PLT4X4: LazyLock<Texture> = LazyLock::new(|| palette(4, 4));
 
 pub fn sample_progress(act: impl Fn(Prefs)) -> Progress {
     let progress = Rc::new(RefCell::new(None));
@@ -101,7 +101,7 @@ pub trait AnySource {
     }
 }
 
-impl AnySource for Lazy<Texture> {
+impl AnySource for LazyLock<Texture> {
     fn texture(&self) -> Texture {
         (self as &Texture).to_owned()
     }
@@ -110,7 +110,7 @@ impl AnySource for Lazy<Texture> {
     }
 }
 
-impl AnySource for (&Lazy<Texture>, (f32, f32)) {
+impl AnySource for (&LazyLock<Texture>, (f32, f32)) {
     fn texture(&self) -> Texture {
         (self.0 as &Texture).to_owned()
     }

--- a/crates/tests/Cargo.toml
+++ b/crates/tests/Cargo.toml
@@ -14,6 +14,3 @@ cli = { path = "../cli" }
 image = { version = "0.25", default-features = false, features = ["png", "webp"] }
 serde_json = "1.0"
 rand = "0.8"
-# TODO: Replace with std::sync::LazyLock when stabilized.
-# https://github.com/rust-lang/rust/issues/109736
-once_cell = "1.19"

--- a/crates/tests/src/common/fixtures.rs
+++ b/crates/tests/src/common/fixtures.rs
@@ -1,10 +1,10 @@
 use crate::common::img;
 use image::RgbaImage;
-use once_cell::sync::Lazy;
 use sprite_dicing::SourceSprite;
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 pub const MONO: &str = "mono";
 pub const ICONS: &str = "icons";
@@ -14,9 +14,9 @@ pub const NESTED: &str = "nested";
 pub const EXOTIC: &str = "exotic";
 pub const INVALID: &str = "invalid";
 
-pub static SRC: Lazy<SourcesByFixture> = Lazy::new(cache_sources);
-pub static DIR: Lazy<DirByFixture> = Lazy::new(cache_dirs);
-pub static RAW: Lazy<RawsByFixture> = Lazy::new(cache_raws);
+pub static SRC: LazyLock<SourcesByFixture> = LazyLock::new(cache_sources);
+pub static DIR: LazyLock<DirByFixture> = LazyLock::new(cache_dirs);
+pub static RAW: LazyLock<RawsByFixture> = LazyLock::new(cache_raws);
 
 pub type SourcesByFixture = HashMap<String, Vec<SourceSprite>>;
 pub type DirByFixture = HashMap<String, PathBuf>;


### PR DESCRIPTION
Use `LazyLock` from std instead, as it's now stabilized.